### PR TITLE
Migration to Kedro 1.0.0 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
       
       - name: Install requirements & package
         run: |
+          export PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install -e .
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+# Use CPU-only PyTorch
 install:
-	pip install .
+	pip install --extra-index-url https://download.pytorch.org/whl/cpu .
 
 build:
 	python -m build

--- a/examples/pipe-deformation/pyproject.toml
+++ b/examples/pipe-deformation/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.kedro]
 package_name = "pipe_deformation"
 project_name = "Pipe Deformation"
-kedro_init_version = "0.19.10"
+kedro_init_version = "1.0.0"
 
 [tool.isort]
 profile = "black"

--- a/examples/pipe-deformation/src/pipe_deformation/pipeline_compose.py
+++ b/examples/pipe-deformation/src/pipe_deformation/pipeline_compose.py
@@ -3,7 +3,7 @@ This is a boilerplate pipeline
 generated using Kedro 0.18.8
 """
 
-from kedro.pipeline import Pipeline, pipeline
+from kedro.pipeline import Pipeline
 from kedro_umbrella import coder, processor, trainer, composer
 from kedro_umbrella.library import *
 
@@ -13,7 +13,7 @@ from kedro_umbrella.library import *
 
 
 def create_pipeline(**kwargs) -> Pipeline:
-    return pipeline(
+    return Pipeline(
         [
             # TRAINING PIPELINE
             processor(
@@ -51,7 +51,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                 inputs=["X_xform", "regressor", "Y_inv_xform"],
                 outputs="comp_model"
             ),
-            processor(inputs=["comp_model", "X_test"], outputs="Y_pred"),
+            processor(name="f_Y_pred", inputs=["comp_model", "X_test"], outputs="Y_pred"),
             processor(
                 func=score,
                 name="score",

--- a/examples/pipe-deformation/src/pipe_deformation/pipeline_full.py
+++ b/examples/pipe-deformation/src/pipe_deformation/pipeline_full.py
@@ -47,10 +47,10 @@ def create_pipeline(**kwargs) -> Pipeline:
                 outputs="regressor",
             ),
             # TESTING PIPELINE
-            processor(inputs=["X_xform", "X_test"], outputs="X_test_red"),
-            processor(inputs=["regressor", "X_test_red"],
+            processor(name="f_test_red", inputs=["X_xform", "X_test"], outputs="X_test_red"),
+            processor(name="f_test_pred", inputs=["regressor", "X_test_red"],
                       outputs="Y_pred_red"),
-            processor(inputs=["Y_inv_xform", "Y_pred_red"], outputs="Y_pred"),
+            processor(name="f_test_invred", inputs=["Y_inv_xform", "Y_pred_red"], outputs="Y_pred"),
             processor(
                 func=score,
                 name="score",

--- a/examples/pipe-deformation/src/pipe_deformation/pipeline_sensitivity.py
+++ b/examples/pipe-deformation/src/pipe_deformation/pipeline_sensitivity.py
@@ -3,7 +3,7 @@ This is a boilerplate pipeline
 generated using Kedro 0.18.8
 """
 
-from kedro.pipeline import Pipeline, pipeline
+from kedro.pipeline import Pipeline
 from kedro_umbrella import coder, processor, trainer
 from kedro_umbrella.library import *
 
@@ -12,7 +12,7 @@ from kedro_umbrella.library import *
 # dis => longer pipeline
 
 def create_pipeline(**kwargs) -> Pipeline:
-    return pipeline(
+    return Pipeline(
         [
             # TRAINING PIPELINE
             processor(

--- a/examples/pipe-deformation/src/pipe_deformation/pipeline_type_error.py
+++ b/examples/pipe-deformation/src/pipe_deformation/pipeline_type_error.py
@@ -47,9 +47,9 @@ def create_pipeline(**kwargs) -> Pipeline:
                 outputs="regressor",
             ),
             # TESTING PIPELINE
-            processor(inputs=["X_xform", "X_test"], outputs="X_test_red"),
-            processor(inputs=["regressor", "X_test_red"], outputs="Y_pred_red"),
-            processor(inputs=["Y_inv_xform", "Y_pred_red"], outputs="Y_pred"),
+            processor(name="f_test_red", inputs=["X_xform", "X_test"], outputs="X_test_red"),
+            processor(name="f_test_pred", inputs=["regressor", "X_test_red"], outputs="Y_pred_red"),
+            processor(name="f_test_invred", inputs=["Y_inv_xform", "Y_pred_red"], outputs="Y_pred"),
             processor(
                 func=score,
                 name="score",

--- a/examples/spring-system/pyproject.toml
+++ b/examples/spring-system/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.kedro]
 package_name = "spring_system"
 project_name = "spring-system"
-kedro_init_version = "0.19.10"
+kedro_init_version = "1.0.0"
 
 [tool.pytest.ini_options]
 addopts = """

--- a/examples/spring-system/src/spring_system/pipeline.py
+++ b/examples/spring-system/src/spring_system/pipeline.py
@@ -1,13 +1,13 @@
-from kedro.pipeline import Pipeline, node, pipeline
+from kedro.pipeline import Pipeline, Node
 from kedro_umbrella import coder, processor, trainer
 from kedro_umbrella.library import *
 from .nodes import *
 
 def create_pipeline(**kwargs) -> Pipeline:
-    return pipeline(
+    return Pipeline(
         [
             # Data Retrieval
-            node(
+            Node(
                 func=get_data,
                 inputs = "params:get_data",
                 outputs=["X", "Y"],

--- a/kedro_umbrella/checker.py
+++ b/kedro_umbrella/checker.py
@@ -14,7 +14,7 @@ from pluggy import PluginManager
 
 from kedro_umbrella import Coder, Processor, Trainer
 from kedro_umbrella.types import TypeCatalog, DataType, FunctionType
-from kedro.pipeline.modular_pipeline import _is_parameter
+from kedro.pipeline.pipeline import _is_parameter
 
 def warn_on_fail(condition, message=""):
     from warnings import warn
@@ -62,7 +62,9 @@ class SequentialChecker(AbstractRunner):
         pipeline: Pipeline,
         catalog: DataCatalog,
         hook_manager: PluginManager = None,
-        session_id: str = None,
+        run_id: str = None,
+        only_missing_outputs: bool = False,
+        **kwargs,
     ) -> None:
         """Run the ``Pipeline`` using the datasets provided by ``catalog``
         and save results back to the same objects.
@@ -71,7 +73,7 @@ class SequentialChecker(AbstractRunner):
             pipeline: The ``Pipeline`` to run.
             catalog: The ``DataCatalog`` from which to fetch data.
             hook_manager: The ``PluginManager`` to activate hooks.
-            session_id: The id of the session.
+            run_id: The id of the session.
 
         Raises:
             ValueError: Raised when ``Pipeline`` inputs cannot be satisfied.
@@ -82,7 +84,6 @@ class SequentialChecker(AbstractRunner):
             by the node outputs.
 
         """
-        catalog = catalog.shallow_copy()
 
         # Check which datasets used in the pipeline are in the catalog or match
         # a pattern in the catalog
@@ -103,13 +104,13 @@ class SequentialChecker(AbstractRunner):
 
         # Create a default dataset for unregistered datasets
         for ds_name in unregistered_ds:
-            catalog.add(ds_name, self.create_default_data_set(ds_name))
+            catalog[ds_name] = self.create_default_data_set(ds_name)
 
         if self._is_async:
             self._logger.info(
                 "Asynchronous mode is enabled for loading and saving data"
             )
-        self._run(pipeline, catalog, hook_manager, session_id)
+        self._run(pipeline, catalog, hook_manager, run_id)
 
         self._logger.info("Pipeline execution completed successfully.")
 
@@ -118,7 +119,9 @@ class SequentialChecker(AbstractRunner):
         pipeline: Pipeline,
         catalog: DataCatalog,
         hook_manager: PluginManager,
-        session_id: str = None,
+        run_id: str = None,
+        only_missing_outputs: bool = False,
+        **kwargs,
     ) -> None:
         """The method implementing sequential pipeline running.
 
@@ -126,7 +129,7 @@ class SequentialChecker(AbstractRunner):
             pipeline: The ``Pipeline`` to run.
             catalog: The ``DataCatalog`` from which to fetch data.
             hook_manager: The ``PluginManager`` to activate hooks.
-            session_id: The id of the session.
+            run_id: The id of the session.
 
         Raises:
             Exception: in case of any downstream node failure.
@@ -141,7 +144,7 @@ class SequentialChecker(AbstractRunner):
             try:
                 self.backtrack_if_needed(pipeline, node)
                 self.check_node(node)
-                # run_node(node, catalog, hook_manager, self._is_async, session_id)
+                # run_node(node, catalog, hook_manager, self._is_async, run_id)
                 done_nodes.add(node)
             except Exception:
                 self._suggest_resume_scenario(pipeline, done_nodes, catalog)
@@ -222,3 +225,7 @@ class SequentialChecker(AbstractRunner):
         else:
             node.check(types)
             return
+        
+    def _get_executor(self, max_workers):
+        """Abstract method in the base class"""
+        return None

--- a/kedro_umbrella/code.py
+++ b/kedro_umbrella/code.py
@@ -4,7 +4,7 @@
 from typing import Any, Callable, Iterable
 
 from kedro.pipeline.node import Node
-from kedro.pipeline.modular_pipeline import _is_parameter
+from kedro.pipeline.pipeline import _is_parameter
 from kedro_umbrella.types import *
 
 

--- a/kedro_umbrella/compose.py
+++ b/kedro_umbrella/compose.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Iterable
 
 from kedro.pipeline.node import Node
 from kedro_umbrella.types import *
-from kedro.pipeline.modular_pipeline import _is_parameter
+from kedro.pipeline.pipeline import _is_parameter
 
 
 class ComposedFunction:

--- a/kedro_umbrella/plugin.py
+++ b/kedro_umbrella/plugin.py
@@ -104,7 +104,7 @@ def commands():
     callback=_split_load_versions,
 )
 @click.option("--pipeline", "-p", type=str, default=None, help=PIPELINE_ARG_HELP)
-@click.option("--namespace", "-ns", type=str, default=None, help=NAMESPACE_ARG_HELP)
+@click.option("--namespaces", "-ns", type=str, default=None, help=NAMESPACE_ARG_HELP)
 @click.option(
     "--config",
     "-c",
@@ -140,7 +140,7 @@ def check(
     config,
     conf_source,
     params,
-    namespace,
+    namespaces,
 ):
     """Run the pipeline."""
     from kedro_umbrella.types import TypeCatalog
@@ -151,7 +151,7 @@ def check(
     tuple_node_names = tuple(node_names)
 
     with KedroSession.create(
-        env=env, conf_source=conf_source, extra_params=params
+        env=env, conf_source=conf_source, runtime_params=params
     ) as session:
         session.run(
             tags=tuple_tags,
@@ -163,5 +163,5 @@ def check(
             to_outputs=to_outputs,
             load_versions=load_versions,
             pipeline_name=pipeline,
-            namespace=namespace,
+            namespaces=namespaces,
         )

--- a/kedro_umbrella/process.py
+++ b/kedro_umbrella/process.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable, Callable
 
 from kedro.pipeline.node import Node, _to_list, _get_readable_func_name
 from kedro_umbrella.types import *
-from kedro.pipeline.modular_pipeline import _is_parameter
+from kedro.pipeline.pipeline import _is_parameter
 from warnings import warn
 
 class Processor(Node):

--- a/kedro_umbrella/template/builder-spring/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipeline.py
+++ b/kedro_umbrella/template/builder-spring/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipeline.py
@@ -1,13 +1,13 @@
-from kedro.pipeline import Pipeline, node, pipeline
+from kedro.pipeline import Pipeline, Node
 from kedro_umbrella import coder, processor, trainer
 from kedro_umbrella.library import *
 from .nodes import *
 
 def create_pipeline(**kwargs) -> Pipeline:
-    return pipeline(
+    return Pipeline(
         [
             # Data Retrieval
-            node(
+            Node(
                 func=get_data,
                 inputs = "params:get_data",
                 outputs=["X", "Y"],

--- a/kedro_umbrella/train.py
+++ b/kedro_umbrella/train.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Iterable
 
 from kedro.pipeline.node import Node
 from kedro_umbrella.types import *
-from kedro.pipeline.modular_pipeline import _is_parameter
+from kedro.pipeline.pipeline import _is_parameter
 
 
 class Trainer(Node):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ onnx==1.17.0
 pandas==2.2.2
 scikit-learn==1.4.0
 scipy==1.15.1
-torch==2.5.1
+torch==2.5.1+cpu
 
 # Infra libs
 black~=22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ setuptools==67.7.2
 # Kedro
 kedro-datasets[pandas.CSVDataset]~=1.0
 kedro-viz~=10.1.0
-kedro==0.19.10
+kedro==1.0.0

--- a/tests/test_node_run.py
+++ b/tests/test_node_run.py
@@ -135,7 +135,7 @@ def test_processor():
     assert out2["dsOut"] == 42
 
     # copy processor
-    p1 = processor(["my_func", "dsIn"], "dsOut")
+    p1 = processor(name="test_proc", inputs=["my_func", "dsIn"], outputs="dsOut")
     p2 = p1._copy()
     assert p1 == p2
 

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -4,9 +4,7 @@ import pytest
 
 from kedro_umbrella import coder, processor, trainer
 from kedro_umbrella.types import TypeCatalog, DataType, FunctionType
-
-from kedro.pipeline import Pipeline, pipeline
-
+from kedro.pipeline import Pipeline
 from kedro.io import DataCatalog
 from kedro_umbrella.checker import SequentialChecker
 
@@ -27,7 +25,7 @@ def test_pipe():
     types.add_data("Y")
 
     # declare pipe
-    pipe = pipeline(
+    pipe = Pipeline(
         [
             coder(
                 func = one_in_one_out, 
@@ -57,13 +55,9 @@ def test_pipe():
     )
 
     catalog = DataCatalog()
-    catalog.add_feed_dict(
-        {
-            "X1": 1,
-            "X2": 2,
-            "Y": 10,
-        }
-    )
+    catalog["X1"] = 1
+    catalog["X2"] = 2
+    catalog["Y"] = 10
     
     SequentialChecker(types).run(pipe, catalog)
 


### PR DESCRIPTION
- Using CPU-only PyTorch (#43)
- Migration to Kedro 1.0.0 (#44)
Private-only example files have been excluded.